### PR TITLE
FusionImages: Improve thumbnail generation once more

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ development
 ===========
 - Use ImageMagick for thumbnail generation in ``FusionImages.py``,
   see also https://github.com/Patent2net/P2N/issues/24
+- Use "Pillow" for thumbnail generation, gracefully fall back to ImageMagick's "convert"
 
 2018-03-20 3.0.0-dev6
 =====================

--- a/Patent2Net/FusionImages.py
+++ b/Patent2Net/FusionImages.py
@@ -1,14 +1,18 @@
 # -*- coding: utf-8 -*-
 # (c) 2017-2018 The Patent2Net Developers
-
 import os
-import epo_ops
 import json
+import logging
 from P2N_Lib import LoadBiblioFile, RenderTemplate
 from P2N_Config import LoadConfig
-from PIL import Image
-from p2n.util import to_png
+from p2n.config import label_from_prefix
+from p2n.util import boot_logging, to_png
 
+logger_name = os.path.basename(__file__).replace('.py', '')
+logger = logging.getLogger(logger_name)
+
+
+# Configure designated size of generated thumbnails
 THUMBNAIL_SIZE = 128, 128
 
 
@@ -19,70 +23,89 @@ def get_patent_label(patent):
 
 
 def generate_thumbnails(img_path):
+
+    # Compute filenames and paths
     img_path = os.path.normpath(img_path)
     base_path, img_fname = os.path.split(img_path)
-    p, ext = os.path.splitext(img_fname)
-    thumb = p + '.tb.png'
-    thumb_f = os.path.normpath(os.path.join(base_path, thumb))
-    orig = p + '.png'
-    orig_f = os.path.normpath(os.path.join(base_path, orig))
-    if not os.path.exists(orig_f):
-        print 'Converting image {}'.format(img_path)
+    filename, ext = os.path.splitext(img_fname)
 
-        # PIL can not handle images with G4 compression
-        
-#        im = Image.open(img_path)
-#        im2 = im.convert('L')
-#        im2.thumbnail(THUMBNAIL_SIZE, Image.LANCZOS)
-#        im2.save(thumb_f, 'PNG')
-#        im = Image.open(img_path)
-#        im.save(orig_f, 'PNG')
-       
+    png_large_name = filename + '.png'
+    png_thumb_name = filename + '.tb.png'
 
-        # Use ImageMagick or other tooling
-        with open(img_path) as tiff:
-            tiff_payload = tiff.read()
+    png_large_path  = os.path.normpath(os.path.join(base_path, png_large_name))
+    png_thumb_path = os.path.normpath(os.path.join(base_path, png_thumb_name))
 
-            # Write original image in PNG format
-            payload_orig = to_png(tiff_payload)
-            with open(orig_f, 'w') as png_orig:
-                png_orig.write(payload_orig)
 
-            # Write thumbnail image in PNG format
+    # Convert original TIFF file to PNG format and also create a thumbnailed version.
+    # Use Pillow, ImageMagick or other tooling.
+    logger.info('Processing image "{}"'.format(img_path))
+    with open(img_path, 'rb') as tiff:
+
+        # Write original image in PNG format
+        # Only process image if not already exists
+        if not os.path.exists(png_large_path):
+            png_large = to_png(tiff)
+            with open(png_large_path, 'wb') as f:
+                f.write(png_large.read())
+
+        tiff.seek(0)
+
+        # Write thumbnail image in PNG format
+        # Only process image if not already exists
+        if not os.path.exists(png_thumb_path):
             width, height = THUMBNAIL_SIZE
-            payload_thumbnail = to_png(tiff_payload, width=width, height=height)
-            with open(thumb_f, 'w') as png_thumbnail:
-				  png_thumbnail.write(payload_thumbnail)
+            png_thumb = to_png(tiff, width=width, height=height)
+            with open(png_thumb_path, 'wb') as f:
+                f.write(png_thumb.read())
 
-    return thumb, orig, img_fname
-
-
-configFile = LoadConfig()
-requete = configFile.requete
-IsEnableScript = configFile.GatherImages
-
-ResultBiblioPath = configFile.ResultBiblioPath
-ResultPathImages = configFile.ResultPathImages
-P2NFamilly = configFile.GatherFamilly
+    return png_thumb_name, png_large_name, img_fname
 
 
-if IsEnableScript:
+def run():
 
-    prefixes = ['']
-    if P2NFamilly:
-        prefixes.append('Families')
+    # Bootstrap logging
+    boot_logging()
 
+    # Load configuration
+    config = LoadConfig()
+
+    # Run this only if enabled
+    if not config.GatherImages:
+        return
+
+    # Get some information from configuration
+    expression = config.requete
+    storage_basedir = config.ResultBiblioPath
+    storage_dirname = config.ndf
+    output_path = config.ResultPathImages
+
+    # Compute prefixes
+    prefixes = [""]
+    if config.GatherFamilly:
+        prefixes.append("Families")
+
+    # Build maps for all prefixes
     for prefix in prefixes:
-        ndf = prefix + configFile.ndf
 
-        biblio_file = LoadBiblioFile(ResultBiblioPath, ndf)
-        patents = biblio_file['brevets']
+        # Status message
+        label = label_from_prefix(prefix)
+        logger.info("Generating gallery of drawings for {}. ".format(label))
+
+        # Compute storage slot using prefix and DataDirectory
+        # e.g. "Lentille" vs. "FamiliesLentille"
+        storage_name = prefix + storage_dirname
+
+        # Load bibliographic data
+        biblio_file = LoadBiblioFile(storage_basedir, storage_name)
+
+        # Generate thumbnails
         gallery = []
+        patents = biblio_file['brevets']
         for patent in patents:
             patent_label = get_patent_label(patent)
             i = 1
-            print 'Processing patent {}'.format(patent_label)
-            path_img_base = '{}//{}-{}.tiff'.format(ResultPathImages, patent_label, '{}')
+            logger.info('Processing patent {}'.format(patent_label))
+            path_img_base = '{}//{}-{}.tiff'.format(output_path, patent_label, '{}')
             path = path_img_base.format(i)
             while os.path.exists(path):
                 thumb, orig, tiff = generate_thumbnails(path)
@@ -97,11 +120,16 @@ if IsEnableScript:
                 })
                 i += 1
                 path = path_img_base.format(i)
-        # print gallery
+
+        # Render gallery
         RenderTemplate(
             'ModeleImages.html',
-            ResultPathImages + '/index' + prefix + '.html',
-            request=requete.replace('"', ''),
+            output_path + '/index' + prefix + '.html',
+            request=expression.replace('"', ''),
             gallery=gallery,
             json=json.dumps(gallery),
         )
+
+
+if __name__ == '__main__':
+    run()

--- a/p2n/util.py
+++ b/p2n/util.py
@@ -233,9 +233,6 @@ def find_program_candidate(candidates):
     for candidate in candidates:
         if os.path.isfile(candidate):
             return candidate
-        else:
-            import where
-            return where.first("magick") + ' convert'
 
 
 def to_png(tiff, width=None, height=None):

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,8 @@ requires = [
     'docopt==0.6.2',
     'jsonpointer==1.12',
     'attrs==17.3.0',
+    'Pillow==5.0.0',
+    'where==1.0.2',
 ]
 
 test_requires = [


### PR DESCRIPTION
Hi there,

this will now be using "Pillow" again for thumbnail generation, but will gracefully fall back to ImageMagick's "convert" if anything fails. This should complete the amendments originating from #24 and #25.

As expected, Pillow is way faster than shelling out to `convert`. Running image conversion for the "Lentille" example takes almost nine minutes with ImageMagick but just 25 seconds when using Pillow on my machine.

With kind regards,
Andreas.
